### PR TITLE
Fix crash on -h

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Для вывода помощи вызовите утилиту без аргументов
 
-```
+```sh
 # wb-modbus-scanner
 Wirenboard modbus extension tool. version: 1.2.0
 Usage: ./wb-modbus-scanner -d device [-b baud] [-s sn] [-i id] [-D]
@@ -45,7 +45,7 @@ Event request examples:
 
 Пример вызова:
 
-```
+```sh
 # wb-modbus-scanner -d /dev/ttyRS485-1 -b 115200
 Serial port: /dev/ttyRS485-1
 Use baud 115200
@@ -63,7 +63,7 @@ End SCAN
 
 Пример вызова:
 
-```
+```sh
 # wb-modbus-scanner -d /dev/ttyRS485-1 -b 115200 -s 4267937719 -i 3
 Serial port: /dev/ttyRS485-1
 Using baud 115200
@@ -74,13 +74,12 @@ Change ID for device with serial   4267937719 [FE638FB7] New ID: 3
 
 Пример вызова:
 
-```
+```sh
 # wb-modbus-scanner -d /dev/ttyRS485-2 -D -i 62 -r0 -t 1 -c 1
 Serial port: /dev/ttyRS485-2
 Use baud 9600
     -> :  3E 46 18 05 01 00 00 01 01 F3 4F
     <- :  3E 46 18 01 01 58 DA
-
 ```
 
 Здесь мы устройству с адресом 62 включили передачу события при изменении coil (type 1) регистра 0 с приоритетом 1
@@ -89,7 +88,7 @@ Use baud 9600
 
 Пример вызова:
 
-```
+```sh
 # wb-modbus-scanner -d /dev/ttyRS485-2 -e 0
 Serial port: /dev/ttyRS485-2
 Using baud 9600
@@ -113,7 +112,7 @@ coil (тип 1) регистр 3 изменил значение, новое з�
 
 Чтобы подтвердить события от данного устройства, и запросить следующие, нужно использовать ключ -e c адресом 62
 
-```
+```sh
 # wb-modbus-scanner -d /dev/ttyRS485-2 -e 62 -D
 Serial port: /dev/ttyRS485-2
 Use baud 9600

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-modbus-ext-scanner (1.2.5) stable; urgency=medium
+
+  * Fix crash on -h
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 27 May 2024 11:15:00 +0400
+
 wb-modbus-ext-scanner (1.2.4) stable; urgency=medium
 
   * Fix typos and grammar

--- a/scanner.c
+++ b/scanner.c
@@ -634,14 +634,14 @@ void tool_event_ctrl(int id, uint8_t type, uint16_t addr, uint8_t val)
     return;
 }
 
-void print_help(char* argv0)
+void print_help(const char* argv0)
 {
         printf(
             "Wirenboard modbus extension tool. version: " VERSION "\n"
             "Usage: %s -d device [-b baud] [-s sn] [-i id] [-D]\n"
             "\n"
             "Options:\n"
-            "    -d device      TTY serial device  \n"
+            "    -d device      TTY serial device\n"
             "    -b baud        Baudrate, default 9600\n"
             "    -L             use 0x60 (deprecated) cmd instead of 0x46 in scan\n"
             "    -s sn          device sn\n"
@@ -653,6 +653,7 @@ void print_help(char* argv0)
             "    -r reg         event control reg\n"
             "    -t type        event control type\n"
             "    -c ctrl        event control value\n"
+            "    -h             show help\n"
             "\n"
             "For scan use:              %s -d device [-b baud] [-D]\n"
             "For scan some old fw use:  %s -d device [-b baud] -L [-D]\n"
@@ -662,7 +663,7 @@ void print_help(char* argv0)
             "         %s -d device [-b baud] -e 0               (request + nothing to confirm)\n"
             "         %s -d device [-b baud] -e 4               (request + confirm events from slave 4 flag 0)\n"
             "         %s -d device [-b baud] -E 6               (request + confirm events from slave 6 flag 1)\n"
-            , argv0, argv0, argv0, argv0, argv0, argv0, argv0);
+            , argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0);
 }
 
 int main(int argc, char *argv[])
@@ -686,7 +687,7 @@ int main(int argc, char *argv[])
     int ev_t = -1;          // event register type
     int ev_c = -1;          // event ctrl value
 
-    while ((c = getopt(argc, argv, "d:b:Ls:i:l:r:t:c:e:E:D")) != -1) {
+    while ((c = getopt(argc, argv, "d:b:Ls:i:l:r:t:c:e:E:Dh")) != -1) {
         switch(c) {
         case 'd':
             printf("Serial port: %s\n", optarg);


### PR DESCRIPTION
Before:
```sh
$ wb-modbus-scanner -h
...
Event request examples:
         wb-modbus-scanner -d device [-b baud] -e 0               (request + nothing to confirm)
         wb-modbus-scanner -d device [-b baud] -e 4               (request + confirm events from slave 4 flag 0)
Segmentation fault
```

After:
```sh
$ wb-modbus-scanner -h
...
Event request examples:
         wb-modbus-scanner -d device [-b baud] -e 0               (request + nothing to confirm)
         wb-modbus-scanner -d device [-b baud] -e 4               (request + confirm events from slave 4 flag 0)
         wb-modbus-scanner -d device [-b baud] -E 6               (request + confirm events from slave 6 flag 1)
```